### PR TITLE
Update install.py

### DIFF
--- a/scripts/install/install.py
+++ b/scripts/install/install.py
@@ -178,7 +178,7 @@ def get_install_dir():
             create_dir(install_dir)
             if os.listdir(install_dir):
                 print_status("'{}' is not empty and may contain a previous installation.".format(install_dir))
-                ans_yes = prompt_y_n('Remove this directory?', 'n')
+                ans_yes = True if ACCEPT_ALL_DEFAULTS else prompt_y_n('Remove this directory?', 'n')
                 if ans_yes:
                     try:
                         shutil.rmtree(install_dir)


### PR DESCRIPTION
This change prevents an infinite loop that occurs when running the install with `--accept-all-defaults` in an environment where the cli has already been installed in the default location.